### PR TITLE
Add "Show Hint" keyboard shortcut in settings

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -319,6 +319,7 @@ void Board::loadSettings()
 	m_controls_left = settings.value("Controls/Left", Qt::Key_Left).toUInt();
 	m_controls_right = settings.value("Controls/Right", Qt::Key_Right).toUInt();
 	m_controls_flag = settings.value("Controls/Flag", Qt::Key_Space).toUInt();
+	m_controls_hint = settings.value("Controls/Hint", Qt::Key_H).toUInt();
 
 	// Load theme
 	m_theme->load(settings.value("Theme", "Mouse").toString());
@@ -374,6 +375,8 @@ void Board::keyPressEvent(QKeyEvent* event)
 		}
 	} else if (keypress == m_controls_flag) {
 		m_maze->cellMutable(m_player.x(), m_player.y()).toggleFlag();
+	} else if (keypress == m_controls_hint) {
+		hint();
 	} else {
 		return;
 	}

--- a/src/board.h
+++ b/src/board.h
@@ -110,6 +110,7 @@ private:
 	unsigned int m_controls_left;
 	unsigned int m_controls_right;
 	unsigned int m_controls_flag;
+	unsigned int m_controls_hint;
 	QPoint m_hint;
 	int m_hint_angle;
 };

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -217,6 +217,7 @@ Settings::Settings(QWidget* parent)
 	controls.append(new ControlButton("Left", Qt::Key_Left, this));
 	controls.append(new ControlButton("Right", Qt::Key_Right, this));
 	controls.append(new ControlButton("Flag", Qt::Key_Space, this));
+	controls.append(new ControlButton("Hint", Qt::Key_H, this));
 
 	QFormLayout * controls_layout = new QFormLayout(controls_tab);
 	controls_layout->addRow(tr("Move Up:"), controls[0]);
@@ -224,6 +225,7 @@ Settings::Settings(QWidget* parent)
 	controls_layout->addRow(tr("Move Left:"), controls[2]);
 	controls_layout->addRow(tr("Move Right:"), controls[3]);
 	controls_layout->addRow(tr("Toggle Flag:"), controls[4]);
+	controls_layout->addRow(tr("Show Hint:"), controls[5]);
 
 
 	// Create Themes tab

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -131,7 +131,7 @@ void Window::initActions()
 	QAction* new_action = game_menu->addAction(fetchIcon("document-new"), tr("&New"), this, SLOT(newGame()), QKeySequence::New);
 	m_pause_action = game_menu->addAction(fetchIcon("media-playback-pause"), tr("&Pause"));
 	m_pause_action->setShortcut(tr("P"));
-	m_hint_action = game_menu->addAction(fetchIcon("games-hint"), tr("&Hint"), m_board, SLOT(hint()), tr("H"));
+	m_hint_action = game_menu->addAction(fetchIcon("games-hint"), tr("&Hint"), m_board, SLOT(hint()));
 	game_menu->addSeparator();
 	game_menu->addAction(fetchIcon("games-highscores"), tr("High &Scores"), m_scores, SLOT(exec()));
 	game_menu->addSeparator();


### PR DESCRIPTION
I wanted to set the H,J,K,L keys for moving the mouse, but the H key seemed to be hard-coded to show a hint. This commit adds an option in settings to change that key. ;)